### PR TITLE
YARP and OpenCV 3 improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 camCalibGpu
 ===========
 
-Modified icub camCalib module to include/offload raw demosaicing and calibration to GPU using opencv (cv::gpu)
+Modified icub camCalib module to include/offload raw demosaicing and calibration to GPU using OpenCV
 
 Original can be found here:
 https://github.com/robotology/icub-main/tree/master/src/modules/camCalib

--- a/include/iCub/CamCalibModule.h
+++ b/include/iCub/CamCalibModule.h
@@ -29,21 +29,21 @@
  * Camera Calibration Port class
  *
  */
-class CamCalibPort : public yarp::os::BufferedPort<yarp::sig::Image>
+class CamCalibPort : public yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >
 {
 private:
-    yarp::os::Port *portImgOut;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > *portImgOut;
     ICalibTool     *calibTool;
 
     bool verbose;
     double t0;
 
-    virtual void onRead(yarp::sig::Image &yrpImgIn);
+    virtual void onRead(yarp::sig::ImageOf<yarp::sig::PixelRgb> &yrpImgIn);
 
 public:
     CamCalibPort();
     
-    void setPointers(yarp::os::Port *_portImgOut, ICalibTool *_calibTool);
+    void setPointers(yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > *_portImgOut, ICalibTool *_calibTool);
     void setVerbose(const bool sw) { verbose=sw; }
 };
 
@@ -60,7 +60,7 @@ class CamCalibModule : public yarp::os::RFModule {
 private:
 
     CamCalibPort    _prtImgIn;
-    yarp::os::Port  _prtImgOut;
+    yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> >  _prtImgOut;
     yarp::os::Port  _configPort;
 
     ICalibTool *    _calibTool;

--- a/include/iCub/ICalibTool.h
+++ b/include/iCub/ICalibTool.h
@@ -26,7 +26,7 @@ public:
     virtual bool close () = 0;
     virtual bool configure (yarp::os::Searchable &config) = 0;
 
-    virtual void apply(const yarp::sig::Image& in,
+    virtual void apply(const yarp::sig::ImageOf<yarp::sig::PixelRgb> & in,
                        yarp::sig::ImageOf<yarp::sig::PixelRgb> & out) = 0;
 
     virtual void setSaturation(double satVal) = 0;

--- a/include/iCub/PinholeCalibTool.h
+++ b/include/iCub/PinholeCalibTool.h
@@ -16,8 +16,14 @@
 #include <math.h>
 
 // opencv
-#include <cv.h>
-#include <opencv2/gpu/gpu.hpp>
+#include <opencv2/opencv.hpp>
+#include <opencv2/core/version.hpp>
+#if CV_MAJOR_VERSION == 2
+    #include <opencv2/gpu/gpu.hpp>
+#elif CV_MAJOR_VERSION == 3
+    #include "opencv2/cudaarithm.hpp"
+    #include "opencv2/cudafilters.hpp"
+#endif
 
 // yarp
 //#include <yarp/sig/Image.h>
@@ -45,10 +51,18 @@ class PinholeCalibTool : public ICalibTool
 
     IplImage        *_mapUndistortX;
     IplImage        *_mapUndistortY;
+
+#if CV_MAJOR_VERSION == 2
 	cv::gpu::GpuMat gpuundistx;
 	cv::gpu::GpuMat gpuundisty;
     cv::gpu::GpuMat gpuundisttmp;
 	std::vector<cv::gpu::GpuMat> gpumatvec;
+#elif CV_MAJOR_VERSION == 3
+    cv::cuda::GpuMat gpuundistx;
+    cv::cuda::GpuMat gpuundisty;
+    cv::cuda::GpuMat gpuundisttmp;
+    std::vector<cv::cuda::GpuMat> gpumatvec;
+#endif
 
     bool _needInit;
 
@@ -107,9 +121,9 @@ public:
     * If necessary the output image is resized to match the size of the 
     * input image.
     */
-    void apply(const yarp::sig::Image& in,
-               yarp::sig::ImageOf<yarp::sig::PixelRgb> & out);    
-    
+    void apply(const yarp::sig::ImageOf<yarp::sig::PixelRgb> & in,
+               yarp::sig::ImageOf<yarp::sig::PixelRgb> & out);
+
 	void setSaturation(double satVal);
 	void setOutputWidth(int w);
 	void setOutputHeight(int h);

--- a/src/CamCalibModule.cpp
+++ b/src/CamCalibModule.cpp
@@ -21,19 +21,19 @@ CamCalibPort::CamCalibPort()
     t0=Time::now();
 }
 
-void CamCalibPort::setPointers(yarp::os::Port *_portImgOut, ICalibTool *_calibTool)
+void CamCalibPort::setPointers(yarp::os::BufferedPort<yarp::sig::ImageOf<yarp::sig::PixelRgb> > *_portImgOut, ICalibTool *_calibTool)
 {
     portImgOut=_portImgOut;
     calibTool=_calibTool;
 }
 
-void CamCalibPort::onRead(Image &yrpImgIn)
+void CamCalibPort::onRead(ImageOf<PixelRgb> &yrpImgIn)
 {
     double t=Time::now();
     // execute calibration
     if (portImgOut!=NULL)
     {        
-        yarp::sig::ImageOf<PixelRgb> yrpImgOut;
+        yarp::sig::ImageOf<PixelRgb> &yrpImgOut=portImgOut->prepare();
 
         if (verbose)
             fprintf(stdout,"received input image after %g [s] ... ",t-t0);
@@ -49,7 +49,7 @@ void CamCalibPort::onRead(Image &yrpImgIn)
         }
         else
         {
-            yrpImgOut.copy(yrpImgIn);
+            yrpImgOut=yrpImgIn;
 
             if (verbose)
                 fprintf(stdout,"just copied in %g [s]\n",Time::now()-t1);
@@ -57,10 +57,10 @@ void CamCalibPort::onRead(Image &yrpImgIn)
 
         //timestamp propagation
         yarp::os::Stamp stamp;
-        BufferedPort<Image>::getEnvelope(stamp);
+        BufferedPort<ImageOf<PixelRgb> >::getEnvelope(stamp);
         portImgOut->setEnvelope(stamp);
 
-        portImgOut->write(yrpImgOut);
+        portImgOut->writeStrict();
     }
 
     t0=t;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
     ResourceFinder rf;
     rf.setVerbose(true);
     rf.setDefaultConfigFile("camCalib.ini");    //overridden by --from parameter
-    rf.setDefaultContext("camCalib");           //overridden by --context parameter
+    rf.setDefaultContext("cameraCalibration");  //overridden by --context parameter
     rf.configure(argc, argv);
     CamCalibModule module;      
     return module.runModule(rf);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,7 @@
  * CopyPolicy: Released under the terms of the GNU GPL v2.0.
  * 
  * Modified version to outsource debayering, optional saturation change and
- * optional debayering to the GPU using cv::gpu (Lars Schillingmann)
+ * optional debayering to the GPU using OpenCV (Lars Schillingmann)
  */
 
  /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,6 @@
 
 // yarp
 #include <yarp/os/Network.h>
-#include <yarp/os/Module.h>
 
 // iCub
 #include <iCub/CalibToolFactory.h>


### PR DESCRIPTION
Hi @lschilli @kt10aan, I made the following changes I was telling you about. Verified working on our robot and a GPU-enabled machine. I would prefer if @kt10aan gave this a shot next week (or whenever he has time) before merging, just in case. :)

Summary:
- support OpenCV 3 CUDA, while retaining compatibility with OpenCV 2 CUDA: at the moment this is done with a bunch of #ifdef's
- update documentation, removing references to cv::gpu (which is OpenCV 2 specific) or cv::cuda (OpenCV 3 specific) but just mentioning OpenCV
- import improvements from original camCalib: for output use BufferedPort,ImageOf<PixelRgb> instead of Port,Image; use cameraCalibration context
